### PR TITLE
Fix: tz conversion bug - just live with a tz!

### DIFF
--- a/octopus_viz/ingestion/management/commands/data_ingestion.py
+++ b/octopus_viz/ingestion/management/commands/data_ingestion.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
             '--period-to',
             type=str,
             default=None,
-            help=('Download data ending on that date (YYYY-MM-DD) - exclusive. No date means today.'),
+            help='Download data ending on that date (YYYY-MM-DD) - exclusive. No date means today.',
         )
         parser.add_argument(
             '--meter-mpan',

--- a/octopus_viz/ingestion/management/commands/data_ingestion.py
+++ b/octopus_viz/ingestion/management/commands/data_ingestion.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
             '--period-to',
             type=str,
             default=None,
-            help=('Download data ending on that date (YYYY-MM-DD) - exclusive.No date means today.'),
+            help=('Download data ending on that date (YYYY-MM-DD) - exclusive. No date means today.'),
         )
         parser.add_argument(
             '--meter-mpan',
@@ -37,6 +37,11 @@ class Command(BaseCommand):
             '--pretend',
             action='store_true',
             help='Do not connect to the Octopus API',
+        )
+        parser.add_argument(
+            '--debug-filename',
+            type=str,
+            help='Save the result from the API to a jsons file instead of to the database.',
         )
 
     @classmethod
@@ -51,12 +56,13 @@ class Command(BaseCommand):
         period_to: str | None = None,
         meter_mpan: str | None = None,
         pretend: bool = False,
+        debug_filename: str | None = None,
         **options,
     ):
         start = self.handle_date(period_from)
         end = self.handle_date(period_to) or timezone.now().date()
 
-        IngestConsumption(CommandAsLogger(self), pretend=pretend).ingest(
+        IngestConsumption(CommandAsLogger(self), pretend=pretend, debug_filename=debug_filename).ingest(
             start,
             end,
             meter_mpan=meter_mpan,

--- a/octopus_viz/ingestion/octopus_client/api.py
+++ b/octopus_viz/ingestion/octopus_client/api.py
@@ -28,7 +28,6 @@ class OctopusAPI:
         octopus_datetime = datetime.fromisoformat(data.pop(field))
         if octopus_datetime.tzinfo is None:
             raise ValueError(f'Unexpected tz unaware {field} from octopus')
-        # return octopus_datetime.astimezone(pytz.UTC)
         return octopus_datetime
 
     def __init__(self, meter: models.Meter, *, logger: logging.Logger | None = None, update_existing: bool = True):

--- a/octopus_viz/ingestion/octopus_client/api.py
+++ b/octopus_viz/ingestion/octopus_client/api.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 from typing import Iterable
 
-import pytz
 import requests
 from django.db import IntegrityError, transaction
 from requests.auth import HTTPBasicAuth
@@ -25,11 +24,12 @@ class OctopusAPI:
 
     @classmethod
     def handle_datetime(cls, data: dict, field: str) -> datetime:
-        """Extract a tz aware datetime from data and return it as a UTC datetime"""
+        """Extract a tz aware datetime from data"""
         octopus_datetime = datetime.fromisoformat(data.pop(field))
         if octopus_datetime.tzinfo is None:
             raise ValueError(f'Unexpected tz unaware {field} from octopus')
-        return octopus_datetime.astimezone(pytz.UTC)
+        # return octopus_datetime.astimezone(pytz.UTC)
+        return octopus_datetime
 
     def __init__(self, meter: models.Meter, *, logger: logging.Logger | None = None, update_existing: bool = True):
         self.meter = meter
@@ -87,10 +87,13 @@ class OctopusAPI:
         req.prepare_url(self.consumption_endpoint, params)
         endpoint = req.url
 
-        self.logger.info(f'Getting data for {self.meter.serial=} for {period_from=} {period_to=}')
+        self.logger.info(
+            f'Getting data for {self.meter} for period_from={params.get("period_from")} period_to={params.get("period_to")}',
+        )
         pages = 0
         while endpoint is not None:
             response = self.session.get(endpoint)
+            self.logger.debug(f'< Got {response.status_code} from {response.url}')
             response.raise_for_status()
 
             data = response.json()

--- a/octopus_viz/octopus_viz/settings.py
+++ b/octopus_viz/octopus_viz/settings.py
@@ -138,7 +138,4 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-}
+LOGGING = {'version': 1, 'disable_existing_loggers': False, 'root': {'handler': ['console'], 'level': 'INFO'}}


### PR DESCRIPTION
- remove tz translation that was creating a shift
- add command to dump data to files to help debug - in the future maybe respect the original format?
- update default logging level to INFO