### PR TITLE
View to fetch data

### DIFF
--- a/octopus_viz/ingestion/templates/admin/add_flux_tariff.html
+++ b/octopus_viz/ingestion/templates/admin/add_flux_tariff.html
@@ -14,6 +14,7 @@
         <i class="{{ card_data.tag.class }}" style="{{ card_data.tag.css }}"></i>
         {% endif %}
         {% if card_data.link %}
+        <br />
         <a href="{{ card_data.link.url }}" class="{{ card_data.link.class }}">
             {{ card_data.link.label }}
         </a>

--- a/octopus_viz/ingestion/templates/ingestion/index.html
+++ b/octopus_viz/ingestion/templates/ingestion/index.html
@@ -12,6 +12,7 @@
         <i class="{{ card_data.tag.class }}" style="{{ card_data.tag.css }}"></i>
         {% endif %}
         {% if card_data.link %}
+        <br />
         <a href="{{ card_data.link.url }}" class="{{ card_data.link.class }}">
             {{ card_data.link.label }}
         </a>

--- a/octopus_viz/ingestion/urls.py
+++ b/octopus_viz/ingestion/urls.py
@@ -1,16 +1,22 @@
 from django.urls import path
 
-import ingestion.views.graphs
-from ingestion.views import home, graphs, configuration
+from ingestion.views import (
+    home,
+    graphs,
+    configuration,
+    ingestion,
+)
 
 urlpatterns = [
     path('', home.HomeView.as_view(), name='home'),
-    path('monthly/', ingestion.views.graphs.MonthlyConsumptionGraphView.as_view(), name='monthly_consumption_graph'),
-    path('tariff/', ingestion.views.graphs.MonthlyTariffGraphView.as_view(), name='monthly_tariff_graph'),
+    path('monthly/', graphs.MonthlyConsumptionGraphView.as_view(), name='monthly_consumption_graph'),
+    path('tariff/', graphs.MonthlyTariffGraphView.as_view(), name='monthly_tariff_graph'),
     # data calls
     path('monthly_data/', graphs.MonthlyGraphData.as_view(), name='monthly_graph_data'),
     path('tariff_data/', graphs.TariffGraphData.as_view(), name='tariff_graph_data'),
     # configuration forms
     path('config/new_flux', configuration.AddOctopusTariffView.as_view(), name='add_new_flux_form'),
     path('config/new_flux/process', configuration.ProcessOctopusTariffView.as_view(), name='process_new_flux_form'),
+    # ingestion APIs
+    path('ingestion/octopus', ingestion.IngestOctopus.as_view(), name='ingestion_octopus'),
 ]

--- a/octopus_viz/ingestion/views/home.py
+++ b/octopus_viz/ingestion/views/home.py
@@ -1,10 +1,13 @@
 import logging
+from datetime import timedelta
 from typing import Iterable
 
+from django import urls
+from django.conf import settings
 from django.db.models import Max
-from django.shortcuts import render
-from django.views import View
-from django.utils.translation import gettext as _
+from django.utils import timezone
+from django.utils.translation import gettext as _, ngettext
+from django.views.generic import TemplateView
 
 from ingestion import models
 from ingestion.views.utils import TariffCardsFactory, CardInfo
@@ -12,15 +15,44 @@ from ingestion.views.utils import TariffCardsFactory, CardInfo
 logger = logging.getLogger(__name__)
 
 
-class HomeView(View):
+class HomeView(TemplateView):
+    template_name = 'ingestion/index.html'
+
     def _last_entry_card(self) -> Iterable[CardInfo]:
         last_entries = models.Consumption.objects.values('meter_id').annotate(
             last_loaded=Max('interval_start'),
         )
+        outdated_meters = 0
+        threshold = timedelta(days=settings.OFFER_DATA_DOWNLOAD_AFTER_DAYS)
         for row in last_entries:
             meter_name = str(models.Meter.objects.get(id=row['meter_id']))
-            when = row['last_loaded'].isoformat()
-            yield CardInfo(_('Last entry for %(meter)s was %(when)s') % dict(meter=meter_name, when=when))
+            when = row['last_loaded'].date().isoformat()
+            card = CardInfo(
+                _('Last entry for %(meter)s was on %(when)s') % dict(meter=meter_name, when=when),
+            )
+            if timezone.now() - row['last_loaded'] >= threshold:
+                outdated_meters += 1
+                yield card.as_warning()
+            else:
+                yield card.as_success()
+
+        if outdated_meters:
+            yield (
+                CardInfo(
+                    ngettext(
+                        '%(n_outdated)d meter do not have updates for more than %(settings)d days.',
+                        '%(n_outdated)d meters do not have updates for more than %(settings)d days.',
+                        outdated_meters,
+                    )
+                    % dict(n_outdated=outdated_meters, settings=threshold.days),
+                )
+                .add_link(
+                    urls.reverse('ingestion_octopus'),
+                    'Retrieve more data',
+                    'btn btn-outline-success',
+                )
+                .as_warning()
+            )
 
     def _consumption_cards(self) -> Iterable[CardInfo]:
         detached_consumption = models.UpdateConsumption.gather_detached_rows(models.Consumption.objects).count()
@@ -43,17 +75,15 @@ class HomeView(View):
                 # TODO(tr) If admin add link to add a Meter
                 yield CardInfo(_('Found %(count)d MPAN without any Meter') % dict(count=no_meter_mpan)).as_warning()
 
-    def get(self, request):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
         cards: list[CardInfo] = list(self._last_entry_card())
         cards.extend(self._consumption_cards())
         cards.extend(self._mpan_cards())
         cards.extend(TariffCardsFactory.electricity_tariff_cards())
 
-        return render(
-            request,
-            'ingestion/index.html',
-            context={
-                'title': _('Data Visualisation'),
-                'cards': cards,
-            },
-        )
+        context.update({
+            'title': _('Data Visualisation'),
+            'cards': cards,
+        })
+        return context

--- a/octopus_viz/ingestion/views/utils.py
+++ b/octopus_viz/ingestion/views/utils.py
@@ -23,8 +23,8 @@ class CardInfo:
         self.tag = dict(self._warning_style.items())
         return self
 
-    def add_link(self, url: str, html_class: str) -> Self:
-        self.link = {'url': url, 'class': html_class}
+    def add_link(self, url: str, label: str, html_class: str) -> Self:
+        self.link = {'url': url, 'label': label, 'class': html_class}
         return self
 
 

--- a/octopus_viz/octopus_viz/settings.py
+++ b/octopus_viz/octopus_viz/settings.py
@@ -139,3 +139,8 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGGING = {'version': 1, 'disable_existing_loggers': False, 'root': {'handler': ['console'], 'level': 'INFO'}}
+
+
+# octopus viz settings
+
+OFFER_DATA_DOWNLOAD_AFTER_DAYS = 7


### PR DESCRIPTION
- Show last date data was fetched by meter.
- Offer view to load data 

Limitations 
- will timeout of too much data should be retrieved
- could offer a filter by meter since the BE offers it
- could offer a few that shows the logging appear by day missing with more filters - but I would need to write some JS for that
- would be better if we required the user to be authenticated to do the action
  - I could simply hide the button for anon users but it's not very nice
  - my quick search I did not find the django auth with redirect I wanted